### PR TITLE
Feature/hook-and-lint: Added Commit-MSG Hooking to Validate Commit Message format

### DIFF
--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -23,7 +23,7 @@ check_commit_message_end() {
 # Function to run lint checks using make
 run_lint_checks() {
     echo "Running make check_lint..."
-    /usr/bin/make -s check_lint
+    /usr/bin/make -s check-lint
     MAKE_STATUS=$?
 
     if [ $MAKE_STATUS -ne 0 ]; then

--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# This script is used to validate the commit message format
+# It checks if the commit message starts with a ticket number or 'WIP'
+
+# Function to validate the commit message against a regex
+validate_commit_message() {
+    REGEX='^(WIP|[A-Z]{2,4}-\d+): .+$'
+    if ! echo "$MESSAGE" | grep -qE "$REGEX"; then
+        echo "Error: commit message must start with a Ticket Number (e.g., ABC-123: <Commit Message>) or WIP <Commit Message>"
+        exit 1
+    fi
+}
+
+# Function to ensure the commit message does not end with a full stop
+check_commit_message_end() {
+    if echo "$MESSAGE" | grep -qE "\.$"; then
+        echo "ERROR: Commit message must not end with a full stop (.)"
+        exit 1
+    fi
+}
+
+# Function to run lint checks using make
+run_lint_checks() {
+    echo "Running make check_lint..."
+    /usr/bin/make -s check_lint
+    MAKE_STATUS=$?
+
+    if [ $MAKE_STATUS -ne 0 ]; then
+        echo "make check_lint failed with status $MAKE_STATUS."
+        exit $MAKE_STATUS
+    fi
+}
+
+# Main execution flow
+main() {
+    # Read the commit message from the file passed as the first argument
+    MESSAGE=$(cat "$1")
+
+    # Validate the commit message format
+    validate_commit_message
+
+    # Check if the commit message ends with a full stop
+    check_commit_message_end
+
+    # Run lint checks
+    run_lint_checks
+
+    exit 0
+}
+
+# Invoke the main function with all script arguments
+main "$@"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# Define a function to run scripts with fallback paths
+define run_script
+	if [ -f "./scripts/$(1).sh" ]; then \
+		./scripts/$(1).sh; \
+	elif [ -f "../../scripts/$(1).sh" ]; then \
+		../../scripts/$(1).sh; \
+	else \
+		echo "Error: $(1).sh script not found"; \
+		exit 1; \
+	fi
+endef
+
+# Targets using the run_script function
+check_lint:
+	$(call run_script,check_lint)
+
+enable_commit_msg_hook:
+	./scripts/enable_commit_msg_hook.sh
+
+disable_commit_msg_hook:
+	rm -f .git/hooks/commit-msg
+
+.PHONY: enable_commit_msg_hook disable_commit_msg_hook check_lint

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,7 @@ commit-msg-hook-enable:
 commit-msg-hook-disable:
 	./scripts/disable_commit_msg_hook.sh
 
-.PHONY: commit-msg-hook-enable commit-msg-hook-disable check_lint
+hook-status:
+	./scripts/hook_status.sh
+
+.PHONY: commit-msg-hook-enable commit-msg-hook-disable check_lint hook-status

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ define run_script
 endef
 
 # Targets using the run_script function
-check_lint:
+check-lint:
 	$(call run_script,check_lint)
 
-enable_commit_msg_hook:
+commit-msg-hook-enable:
 	./scripts/enable_commit_msg_hook.sh
 
-disable_commit_msg_hook:
+commit-msg-hook-disable:
 	./scripts/disable_commit_msg_hook.sh
 
-.PHONY: enable_commit_msg_hook disable_commit_msg_hook check_lint
+.PHONY: commit-msg-hook-enable commit-msg-hook-disable check_lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Define a function to run scripts with fallback paths
+# Will be used when git-hooks execute make command from .git/hooks directory
 define run_script
 	if [ -f "./scripts/$(1).sh" ]; then \
 		./scripts/$(1).sh; \
@@ -18,6 +19,6 @@ enable_commit_msg_hook:
 	./scripts/enable_commit_msg_hook.sh
 
 disable_commit_msg_hook:
-	rm -f .git/hooks/commit-msg
+	./scripts/disable_commit_msg_hook.sh
 
 .PHONY: enable_commit_msg_hook disable_commit_msg_hook check_lint

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,8 @@
 import js from '@eslint/js'
-import globals from 'globals'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import globals from 'globals'
 
 export default [
   { ignores: ['dist'] },
@@ -10,7 +10,12 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2020,
+        ...globals.jest,
+      },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "TODO yarn lint here"
+exit 0

--- a/scripts/disable_commit_msg_hook.sh
+++ b/scripts/disable_commit_msg_hook.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Remove the commit-msg hook if it exists
+if [ -L ".git/hooks/commit-msg" ] || [ -e ".git/hooks/commit-msg" ]; then
+    echo "Removing existing commit-msg hook in .git/hooks..."
+    rm -f .git/hooks/commit-msg
+    echo "commit-msg hook disabled."
+else
+    echo "No commit-msg hook found in .git/hooks."
+fi

--- a/scripts/enable_commit_msg_hook.sh
+++ b/scripts/enable_commit_msg_hook.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Function to symlink the Makefile in .git/hooks
+symlink_makefile() {
+    if [ -L ".git/hooks/Makefile" ] || [ -e ".git/hooks/Makefile" ]; then
+        echo "Removing existing Makefile in .git/hooks..."
+        rm -f .git/hooks/Makefile
+    fi
+    echo "Symlinking Makefile to .git/hooks..."
+    ln -s ../../Makefile .git/hooks/Makefile
+    echo "Makefile symlinked."
+}
+
+# Function to enable the commit-msg hook
+enable_commit_msg_hook() {
+    if [ -L ".git/hooks/commit-msg" ] || [ -e ".git/hooks/commit-msg" ]; then
+        echo "Removing existing commit-msg hook in .git/hooks..."
+        rm -f .git/hooks/commit-msg
+    fi
+    echo "Enabling commit-msg hook..."
+    cp .git-hooks/commit-msg .git/hooks/commit-msg
+    chmod +x .git/hooks/commit-msg
+    echo "Commit-msg hook enabled. Type 'git commit -m \"Your message\"' to test."
+}
+
+# Main function to orchestrate the setup
+main() {
+    if [ -d ".git" ]; then
+        symlink_makefile
+        enable_commit_msg_hook
+    else
+        echo "Not a git repository, try git init first."
+    fi
+}
+
+# Invoke the main function
+main

--- a/scripts/hook_status.sh
+++ b/scripts/hook_status.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Directory containing the hooks
+hooks_dir=".git/hooks"
+
+# Check if the hooks directory exists
+if [ ! -d "$hooks_dir" ]; then
+    echo "Error: Git hooks directory not found."
+    exit 1
+fi
+
+# Initialize an array to store enabled hooks
+enabled_hooks=()
+
+# List of files to ignore
+ignore_list=("Makefile")
+
+# Scan the hooks directory
+for hook in "$hooks_dir"/*; do
+    # Extract the filename without the path
+    hook_name=$(basename "$hook")
+    
+    # Check if the file is a regular file and doesn't have a .sample extension
+    if [ -f "$hook" ] && \
+    [[ ! "$hook" == *.sample ]] && \
+    [[ ! "${ignore_list[@]}" =~ "$hook_name" ]]; then
+        enabled_hooks+=("$hook_name")
+    fi
+done
+
+# Display the results
+if [ ${#enabled_hooks[@]} -eq 0 ]; then
+    echo "No hooks are currently enabled."
+else
+    echo "Enabled hooks:"
+    for hook in "${enabled_hooks[@]}"; do
+        echo "- $hook"
+    done
+fi


### PR DESCRIPTION
- Using Git Hook (commit-msg) to Validate the commit message format | no Husky needed ;) 
Here are the Valid Formats for now:
    - Start with a Ticket Number (e.g. LINT-1: ENV lang extension added) or
    - Start with WIP (e.g. WIP Linter setup not done yet) | WIP (work in progress)
    - Commit message must not end with a Dot (.) 
- Automation with Makefile 
    - You can enable/disable commit-msg hooks  
    - Enable Hook by running `make commit-msg-hook-enable` 
    - Disable Hook by running `make commit-msg-hook-disable`
    - You can also check Enabled Hooks `make hook-status`
    - I set an alias for it like this `alias hooks="make hook-status"`